### PR TITLE
Build wheels

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,72 +1,27 @@
-on:
-  push:
-  pull_request:
-    branches:
-      - master
-  workflow_dispatch:
+name: Build
+
+on: [push, pull_request]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Install pip and development dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements_develop.txt
-
-      - name: Build package
-        run: |
-          python -m cython quadprog/quadprog.pyx
-          python -m build --sdist
-
-      - name: Upload package
-        uses: actions/upload-artifact@v2
-        with:
-          name: sdist
-          path: dist/quadprog*.tar.gz
-
-  test:
-    needs: build
-
-    runs-on: ubuntu-latest
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.6.1
+        env:
+          # Disable building for PyPy, 32bit
+          CIBW_SKIP: pp* *-win32 *-manylinux_i686 *-musllinux*
+          # Run the tests.
+          CIBW_BEFORE_TEST: pip install -r requirements_test.txt
+          CIBW_TEST_COMMAND: pytest {project}/tests
+
+      - uses: actions/upload-artifact@v2
         with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install pip and test dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements_test.txt
-
-      - name: Download package
-        uses: actions/download-artifact@v2
-        with:
-          name: sdist
-          path: dist
-
-      - name: Install package
-        run: |
-          pip install dist/quadprog*.tar.gz
-
-      - name: Run tests
-        run: |
-          pytest
+          path: ./wheelhouse/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ quadprog.so
 quadprog.egg-info/
 dist/
 tests/__pycache__/
+/.tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include quadprog/linear-algebra.c
+include quadprog/qr-update.c
+include quadprog/solve.QP.c
+include quadprog/quadprog.pyx

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ References
 ```
 
 ### Installation
-`pip install quadprog`
+`pip install quadprog-wheel`
 
 ### Dependencies
 - Runtime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "Cython"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from Cython.Build import cythonize
 from setuptools import setup, Extension
 
 long_description = """Minimize     1/2 x^T G x - a^T x
@@ -27,12 +28,19 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics"
 ]
 
-extensions = [Extension('quadprog', [
-    'quadprog/linear-algebra.c',
-    'quadprog/qr-update.c',
-    'quadprog/quadprog.c',
-    'quadprog/solve.QP.c',
-])]
+ext_modules=cythonize(
+    [
+        Extension(
+            "quadprog",
+            [
+                'quadprog/linear-algebra.c',
+                'quadprog/qr-update.c',
+                'quadprog/solve.QP.c',
+                'quadprog/quadprog.pyx',
+            ],
+        )
+    ],
+)
 
 setup(
     name="quadprog",
@@ -44,6 +52,14 @@ setup(
     author_email='rmcgibbo@gmail.com',
     license='GPLv2+',
     classifiers=classifiers,
-    ext_modules=extensions,
-    install_requires=["numpy"]
+    ext_modules=ext_modules,
+    install_requires=["numpy"],
+    package_data= {
+        "quadprog": [
+            'quadprog/linear-algebra.c',
+            'quadprog/qr-update.c',
+            'quadprog/solve.QP.c',
+            'quadprog/quadprog.pyx',
+            ]
+        }
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering :: Mathematics"
 ]
 
@@ -43,9 +44,9 @@ ext_modules=cythonize(
 )
 
 setup(
-    name="quadprog",
+    name="quadprog-wheel",
     version="0.1.11",
-    description="Quadratic Programming Solver",
+    description="Quadratic Programming Solver with wheel packages",
     long_description=long_description,
     url="https://github.com/quadprog/quadprog",
     author="Robert T. McGibbon",
@@ -53,13 +54,6 @@ setup(
     license='GPLv2+',
     classifiers=classifiers,
     ext_modules=ext_modules,
+    python_requires=">=3.6, <3.11",
     install_requires=["numpy"],
-    package_data= {
-        "quadprog": [
-            'quadprog/linear-algebra.c',
-            'quadprog/qr-update.c',
-            'quadprog/solve.QP.c',
-            'quadprog/quadprog.pyx',
-            ]
-        }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+isolated_build = true
+envlist = py{36,37,38,39}
+
+[testenv]
+deps =
+    -r requirements_test.txt
+commands =
+    pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,7 @@
 [tox]
 isolated_build = true
-envlist = py{36,37,38,39}
 
 [testenv]
-deps =
-    -r requirements_test.txt
+deps = -r requirements_test.txt
 commands =
     pytest {posargs}


### PR DESCRIPTION
This PR adds building the package wheels on linux, macos and windows for python 3.6, 3.7, 3.8 and 3.9.
This is based on [cibuildwheel](https://cibuildwheel.readthedocs.io), each wheel is tested with the unit tests.
A [tox](https://tox.wiki/en/latest/) configuration file is added to easily run the test by just running `tox` in a console.