### PR TITLE
Add the ".pyx" file to setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel", "Cython"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup, Extension
-
 long_description = """Minimize     1/2 x^T G x - a^T x
 
 Subject to   C.T x >= b
@@ -24,19 +23,21 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Scientific/Engineering :: Mathematics"
 ]
 
 extensions = [Extension('quadprog', [
     'quadprog/linear-algebra.c',
     'quadprog/qr-update.c',
-    'quadprog/quadprog.c',
+    'quadprog/quadprog.pyx',
     'quadprog/solve.QP.c',
 ])]
 
 setup(
     name="quadprog",
-    version="0.1.11",
+    version="0.1.12",
     description="Quadratic Programming Solver",
     long_description=long_description,
     url="https://github.com/quadprog/quadprog",


### PR DESCRIPTION
This change removes the `quadprog.c` file from the `setup.py` extentions and replaces it with the orginal `quadprog.pyx`. This means that when wheels are built Cython will now cythonize the `quadprog.pyx` -> `quadprog.c`automatically.

The main idea of this fix would be that it will allow the wheels to be built from source by pip, if they do not exist. I.e for Python 3.11 and all future versions. 

I have tested this on my computer and it seems to work well