### PR TITLE
python 3.13 support

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   push:
     branches: [master]

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.21.3
         env:
           # Disable building for PyPy, 32bit
           CIBW_SKIP: pp* *-win32 *-manylinux_i686 *-musllinux*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,5 @@
+name: Release
+
 on:
   push:
     tags: ["v*"]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4.4.3
         with:
+          name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
           retention-days: 1
 

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,6 +1,5 @@
 on:
-  push:
-    tags: ["v*"]
+  workflow_dispatch:
 
 jobs:
   build_wheels:
@@ -60,3 +59,5 @@ jobs:
 
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,7 +1,6 @@
 name: Test release
 
 on:
-  push:
   workflow_dispatch:
 
 jobs:
@@ -50,7 +49,7 @@ jobs:
           retention-days: 1
 
   upload_to_pypi:
-    name: Upload to PyPI
+    name: Upload to Test PyPI
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,4 +1,7 @@
+name: Test release
+
 on:
+  push:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -25,6 +25,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4.4.3
         with:
+          name: wheels-${{ matrix.os }}
           path: ./wheelhouse/*.whl
           retention-days: 1
 

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ extensions = [Extension('quadprog', [
 
 setup(
     name="quadprog",
-    version="0.1.12",
-    python_requires=">=3.8",
+    version="0.1.13",
+    python_requires=">=3.9",
     description="Quadratic Programming Solver",
     long_description=long_description,
     url="https://github.com/quadprog/quadprog",


### PR DESCRIPTION
Bumps the version to support python 3.13 and drop support for python 3.8. No other change was made, this is just a new build.